### PR TITLE
updated to keras 2.2.2

### DIFF
--- a/vgg16_places_365.py
+++ b/vgg16_places_365.py
@@ -21,7 +21,7 @@ from keras.regularizers import l2
 from keras.layers.core import Dropout
 from keras.layers import GlobalAveragePooling2D
 from keras.layers import GlobalMaxPooling2D
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.engine.topology import get_source_inputs
 from keras.utils.data_utils import get_file
 from keras.utils import layer_utils


### PR DESCRIPTION
In Keras 2.2.2 there is no `_obtain_input_shape` method in the `keras.applications.imagenet_utils` module.
Now this method in `keras_applications` module